### PR TITLE
Agrego zlib a la instalación en Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM node:12.12.0-alpine as frontend
 
 ## Install system dependencies
 RUN apk --update add --no-cache \
-    git gcc make autoconf automake musl-dev \
+    git gcc make autoconf automake musl-dev zlib zlib-dev\
   && rm -rf /var/cache/apk/* /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Set working directory


### PR DESCRIPTION
Agrego zlib y zlib-dev en el Dockerfile para el frontend.

Esto se debe a que cuando se realiza la instalación, al levantar
el reactjs, se produce un error, dónde se pide zlib como depedencia.

Fix #633 