### PR TITLE
Se agrega Sentry para el entorno de staging/production

### DIFF
--- a/eventol/eventol/settings.py
+++ b/eventol/eventol/settings.py
@@ -9,7 +9,7 @@ from configurations import Configuration
 from django.utils.translation import ugettext_lazy as _
 from easy_thumbnails.conf import Settings as thumbnail_settings
 from easy_thumbnails.optimize.conf import OptimizeSettings
-
+import raven
 
 def str_to_bool(str_bool):
     return str_bool == 'True'
@@ -390,7 +390,12 @@ class Staging(Base):
     STATIC_ROOT = os.path.join(BASE_DIR, 'static')
     STATIC_URL = '/static/'
     MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
-    MEDIA_URL = '/media/'
+    MEDIA_URL = '/media/'    
+    INSTALLED_APPS += ('raven.contrib.django.raven_compat',) # NOQA
+    RAVEN_CONFIG = {
+        'dsn': os.environ.get("SENTRY_DSN", "NOT_CONFIGURED"),
+        'release': raven.fetch_git_sha(BASE_DIR),  # NOQA
+    }
 
 
 class Prod(Staging):

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,4 +27,4 @@ CairoSVG==2.1.1
 pypng==0.0.18
 django-tempus-dominus==5.1.2.8
 tablib==0.13.0
-
+raven==6.9.0


### PR DESCRIPTION
La opcion de Sentry es opcional...

Se esta usando la vieja opcion de sentry porque la nueva forma de configurarlo requiere una version mas actualizada de Django