### PR TITLE
pypng upgrade: from 0.0.18 to 0.0.21 to avoid 'use_2to3 is invalid' e…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ Pillow==9.0.1
 posix-ipc==1.1.1
 psycopg2-binary==2.8.6
 PyJWT==2.10.1
-pypng==0.0.18
+pypng==0.0.21
 PyQRCode==1.2.1
 python3-openid==3.2.0
 python3-saml==1.16.0


### PR DESCRIPTION
Si tenes instalado setuptools >58 el paquete pypng no va a funcionar. Se necesita actualizar pypng a una versión mayor que ya no soporte python 2.

```
   1   | Collecting pypng==0.0.18 (from -r requirements.txt (line 35))
   2   │   Downloading pypng-0.0.18.tar.gz (377 kB)
   3   │   Installing build dependencies ... done
   4   │   Getting requirements to build wheel ... error
   5   │   error: subprocess-exited-with-error
   6   │   
   7   │   × Getting requirements to build wheel did not run successfully.
   8   │   │ exit code: 1
   9   │   ╰─> [1 lines of output]
  10   │       error in pypng setup command: use_2to3 is invalid.
  11   │       [end of output]
```