### PR TITLE
Upgrade django-autofixture: fix on setuptools config

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
 
-django-autofixture @ git+https://github.com/josx/django-autofixture@dba7174ba68be6448eacb280cd66fa49fcce1092
+django-autofixture @ git+https://github.com/josx/django-autofixture@2c431f3dd0ea35b040ff170b10ddc920f3b0378b
 django-debug-toolbar==3.5.0
 ipdb
 ipython


### PR DESCRIPTION
Hubo que arreglar esta dependencias porque no funcionaba a la hora de instalar (que además habiamos hecho compatible con django v4). 

Entonces ahora apunta a una rama que permite la instalación.